### PR TITLE
Redis logfile does not exist on start

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,5 +31,27 @@
 - include_tasks: setup-Archlinux.yml
   when: ansible_os_family == 'Archlinux'
 
+- name: Check if log file exists
+  stat:
+    path: "{{redis_logfile}}"
+  register: redis_logfile_stat
+
+- name: Ensure log file directory exists and has correct owner
+  file:
+    path: "{{redis_logfile|dirname}}"
+    state: directory
+    owner: redis
+    group: redis
+    mode: 0750
+
+- name: Ensure log file exists and is writable by Redis Server
+  file:
+    path: "{{redis_logfile}}"
+    state: touch
+    owner: redis
+    group: redis
+    mode: 0640
+  when: redis_logfile_stat.stat.exists == False
+
 - name: Ensure Redis is running and enabled on boot.
   service: "name={{ redis_daemon }} state=started enabled=yes"


### PR DESCRIPTION
```
TASK [geerlingguy.redis : Ensure Redis is running and enabled on boot.] ********
fatal: [redis]: FAILED! => {"changed": false, "msg": "Unable to start service redis: Job for redis.service failed because the control process exited with error code. See \"systemctl status redis.service\" and \"journalctl -xe\" for details.\n"}

PLAY RECAP *********************************************************************
redis                      : ok=10   changed=0    unreachable=0  
```

After evaluating the error, it appears later versions of redis are expecting the logfile to already be created vs creating.

```
Aug 23 16:01:19 redis systemd[1]: Failed to start Redis persistent key-value database.
-- Subject: Unit redis.service has failed
-- Defined-By: systemd
-- Support: http://lists.freedesktop.org/mailman/listinfo/systemd-devel
-- 
-- Unit redis.service has failed.
-- 
-- The result is failed.
Aug 23 16:01:19 redis redis-server[4310]: *** FATAL CONFIG FILE ERROR ***
Aug 23 16:01:19 redis redis-server[4310]: Reading the configuration file, at line 12
Aug 23 16:01:19 redis redis-server[4310]: >>> 'logfile /var/log/redis/redis-server.log'
Aug 23 16:01:19 redis redis-server[4310]: Can't open the log file: Permission denied
Aug 23 16:01:19 redis systemd[1]: Unit redis.service entered failed state.
Aug 23 16:01:19 redis systemd[1]: redis.service failed.
Aug 23 16:01:19 redis polkitd[330]: Unregistered Authentication Agent for unix-process:4304:20064 (system bus name :1.78, object path /org/freedesktop/Polic
[root@redis ~]# exit

```